### PR TITLE
VariableDefinitions added.

### DIFF
--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -6,6 +6,10 @@
 // subjet finding
 #include "JetSubStructureUtils/SubjetFinder.h"
 
+#include "TheAccountant/VariableDefinitions.h"
+
+namespace VD = VariableDefinitions;
+
 TheAccountant::JetHists::JetHists (std::string name) :
   HistogramManager(name, "")
 {
@@ -67,16 +71,13 @@ EL::StatusCode TheAccountant::JetHists::execute( const xAOD::JetContainer* jets,
 }
 
 EL::StatusCode TheAccountant::JetHists::execute( const xAOD::Jet* jet, float eventWeight ){
-  static SG::AuxElement::ConstAccessor<float> Tau1("Tau1");
-  static SG::AuxElement::ConstAccessor<float> Tau2("Tau2");
-  static SG::AuxElement::ConstAccessor<float> Tau3("Tau3");
   static SG::AuxElement::ConstAccessor<float> Width("Width");
 
   m_massOverPt->Fill( jet->m()/jet->pt(), eventWeight );
 
   // subjettiness
-  if(Tau1.isAvailable(*jet) && Tau2.isAvailable(*jet)) m_tau21->Fill( Tau2(*jet)/Tau1(*jet), eventWeight);
-  if(Tau2.isAvailable(*jet) && Tau3.isAvailable(*jet)) m_tau32->Fill( Tau3(*jet)/Tau2(*jet), eventWeight);
+  m_tau21->Fill( VD::Tau21(jet), eventWeight);
+  m_tau32->Fill( VD::Tau32(jet), eventWeight);
 
   // default to using the kt_algorithm and 0.2 radius
   fastjet::JetAlgorithm subjet_clustering(fastjet::kt_algorithm);

--- a/Root/OptimizationDump.cxx
+++ b/Root/OptimizationDump.cxx
@@ -43,7 +43,10 @@ OptimizationDump :: OptimizationDump () :
   m_totalTransverseMomentum(-999.0),
   m_totalTransverseMass(-999.0),
   m_numBJets(-99),
-  m_numJets(-99)
+  m_numJets(-99),
+  m_topTag_Loose(0),
+  m_topTag_Medium(0),
+  m_topTag_Tight(0)
 {}
 
 EL::StatusCode OptimizationDump :: setupJob (EL::Job& job)
@@ -77,6 +80,10 @@ EL::StatusCode OptimizationDump :: initialize () {
   m_tree->Branch ("mt",   &m_totalTransverseMass, "mt/F");
   m_tree->Branch ("n_b",  &m_numBJets, "n_b/I");
   m_tree->Branch ("n_j",  &m_numJets, "n_j/I");
+
+  m_tree->Branch ("n_t_loose", &m_topTag_Loose, "n_t_loose/I");
+  m_tree->Branch ("n_t_medium", &m_topTag_Medium, "n_t_medium/I");
+  m_tree->Branch ("n_t_tight", &m_topTag_Tight, "n_t_tight/I");
 
   return EL::StatusCode::SUCCESS;
 }
@@ -132,6 +139,11 @@ EL::StatusCode OptimizationDump :: execute ()
   m_totalTransverseMass = VD::mT(in_met, in_muons, in_electrons);
   m_numBJets = in_bjets->size();
   m_numJets = in_jets->size();
+
+  // tagging variables
+  m_topTag_Loose  = VD::topTag(eventInfo, in_jets, VD::WP::Loose);
+  m_topTag_Medium = VD::topTag(eventInfo, in_jets, VD::WP::Medium);
+  m_topTag_Tight  = VD::topTag(eventInfo, in_jets, VD::WP::Tight);
 
   // fill in all variables
   m_tree->Fill();

--- a/Root/VariableDefinitions.cxx
+++ b/Root/VariableDefinitions.cxx
@@ -13,7 +13,32 @@
 // c++ includes
 #include <math.h>
 
+// substructure
+#include <JetSubStructureUtils/Nsubjettiness.h>
+#include "JetSubStructureUtils/KtSplittingScale.h"
+
 namespace VD = VariableDefinitions;
+
+std::string VD::wp2str(VD::WP wp){
+  switch(wp){
+    case VD::WP::VeryLoose:
+      return "VeryLoose";
+    break;
+    case VD::WP::Loose:
+      return "Loose";
+    break;
+    case VD::WP::Medium:
+      return "Medium";
+    break;
+    case VD::WP::Tight:
+      return "Tight";
+    break;
+  }
+
+  // should never reach here, we should be synced with the enum class
+  return "BadWorkingPoint";
+}
+
 
 float VD::Meff(const xAOD::MissingET* met, const xAOD::JetContainer* jets, int numJets, const xAOD::MuonContainer* muons, const xAOD::ElectronContainer* els){
   float meff(0.0);
@@ -71,4 +96,177 @@ float VD::mT(const xAOD::MissingET* met, const xAOD::MuonContainer* muons, const
 
   mt = 2*leadingLepton->pt()*met->met()*(1-cos(xAOD::P4Helpers::deltaPhi(leadingLepton, met)));
   return sqrt(fabs(mt));
+}
+
+int VD::topTag(const xAOD::EventInfo* eventInfo, const xAOD::JetContainer* jets, VD::WP wp){
+
+  static SG::AuxElement::Decorator< int > nTops_wp("nTops_"+VD::wp2str(wp));
+
+  // set or reset to 0 top tags
+  nTops_wp(*eventInfo) = 0;
+
+  // loop over jets, tag, and count top tags
+  int nTops(0);
+  for(auto jet: *jets) nTops += static_cast<int>(VD::topTag(jet, wp));
+
+  // tag the event itself with # of jets tagged
+  nTops_wp(*eventInfo) = nTops;
+  return nTops;
+}
+
+bool VD::topTag(const xAOD::Jet* jet, VD::WP wp){
+  bool isTop_tagged = false;
+  switch(wp){
+    case VD::WP::Loose:
+    {
+      isTop_tagged = (jet->m()/1.e3 > 100.) &&
+                     (VD::Split12(jet)/1.e3 > 40.);
+    }
+    break;
+    case VD::WP::Medium:
+    {
+      isTop_tagged = (jet->m()/1.e3 > 100.) &&
+                     (VD::Split12(jet)/1.e3 > 40.) &&
+                     (VD::Split23(jet)/1.e3 > 20.);
+    }
+    break;
+    case VD::WP::Tight:
+    {
+      float tau21 = VD::Tau21(jet);
+      float tau32 = VD::Tau32(jet);
+
+      isTop_tagged = (VD::Split12(jet)/1.e3 > 40.) &&
+                     (tau21 > 0.4 && tau21 < 0.9) &&
+                     (tau32 < 0.65);
+    }
+    break;
+    default:
+    {
+      isTop_tagged = false;
+    }
+    break;
+  }
+
+  static SG::AuxElement::Decorator< int > isTop_wp("isTop_"+VD::wp2str(wp));
+  // tag the jet
+  isTop_wp(*jet) = static_cast<int>(isTop_tagged);
+
+  return isTop_tagged;
+}
+
+float VD::Tau21(const xAOD::Jet* jet){
+  float tau21(0.0), tau1(0.0), tau2(0.0);
+
+  if(jet->getAttribute("Tau21", tau21)){
+    return tau21;
+  } else if(jet->getAttribute("Tau1", tau1) && jet->getAttribute("Tau2", tau2)){
+    static SG::AuxElement::Decorator< float > Tau21("Tau21");
+    Tau21(*jet) = tau2/tau1;
+    return tau2/tau1;
+  } else {
+    // this should never be called, but we include it
+    std::cout << "Warning <VariableDefinition>: Calculating subjettiness." << std::endl;
+    VD::Nsubjettiness(jet);
+    return VD::Tau21(jet);
+  }
+}
+
+float VD::Tau32(const xAOD::Jet* jet){
+  float tau32(0.0), tau2(0.0), tau3(0.0);
+
+  if(jet->getAttribute("Tau32", tau32)){
+    return tau32;
+  } else if(jet->getAttribute("Tau2", tau2) && jet->getAttribute("Tau3", tau3)){
+    static SG::AuxElement::Decorator< float > Tau32("Tau32");
+    Tau32(*jet) = tau3/tau2;
+    return tau3/tau2;
+  } else {
+    // this should never be called, but we include it
+    std::cout << "Warning <VariableDefinition>: Calculating subjettiness." << std::endl;
+    VD::Nsubjettiness(jet);
+    return VD::Tau32(jet);
+  }
+}
+
+void VD::Nsubjettiness(const xAOD::Jet* jet, float alpha){
+  fastjet::contrib::NormalizedCutoffMeasure normalized_measure(alpha, jet->getSizeParameter(), 1000000);
+  fastjet::contrib::KT_Axes kt_axes;
+
+  JetSubStructureUtils::Nsubjettiness tau1_cal(1, kt_axes, normalized_measure);
+  JetSubStructureUtils::Nsubjettiness tau2_cal(2, kt_axes, normalized_measure);
+  JetSubStructureUtils::Nsubjettiness tau3_cal(3, kt_axes, normalized_measure);
+
+  // compute the subjettiness
+  float tau1 = tau1_cal.result(*jet);
+  float tau2 = tau2_cal.result(*jet);
+  float tau3 = tau3_cal.result(*jet);
+
+  // set up decorators for setting the properties
+  static SG::AuxElement::Decorator< float > Tau1("Tau1");
+  static SG::AuxElement::Decorator< float > Tau2("Tau2");
+  static SG::AuxElement::Decorator< float > Tau3("Tau3");
+  static SG::AuxElement::Decorator< float > Tau21("Tau21");
+  static SG::AuxElement::Decorator< float > Tau32("Tau32");
+
+  // start decorating our jets
+  Tau1(*jet) = tau1;
+  Tau2(*jet) = tau2;
+  Tau3(*jet) = tau3;
+
+  if(fabs(tau1) > 1e-8) // Prevent div-0
+    Tau21(*jet) = tau2/tau1;
+  else
+    Tau21(*jet) = -999.0;
+  if(fabs(tau2) > 1e-8) // Prevent div-0
+    Tau32(*jet) = tau3/tau2;
+  else
+    Tau32(*jet) = -999.0;
+
+  return;
+}
+
+float VD::Split12(const xAOD::Jet* jet){
+  float split12(0.0);
+  if(jet->getAttribute("Split12", split12)){
+      return split12;
+  } else {
+    VD::KtSplittingScale(jet);
+    return VD::Split12(jet);
+  }
+}
+
+float VD::Split23(const xAOD::Jet* jet){
+  float split23(0.0);
+  if(jet->getAttribute("Split23", split23)){
+      return split23;
+  } else {
+    VD::KtSplittingScale(jet);
+    return VD::Split23(jet);
+  }
+}
+
+float VD::Split34(const xAOD::Jet* jet){
+  float split34(0.0);
+  if(jet->getAttribute("Split34", split34)){
+      return split34;
+  } else {
+    VD::KtSplittingScale(jet);
+    return VD::Split34(jet);
+  }
+}
+
+void VD::KtSplittingScale(const xAOD::Jet* jet){
+  static SG::AuxElement::Decorator< float > Split12("Split12");
+  static SG::AuxElement::Decorator< float > Split23("Split23");
+  static SG::AuxElement::Decorator< float > Split34("Split34");
+
+  JetSubStructureUtils::KtSplittingScale split12_cal(1);
+  JetSubStructureUtils::KtSplittingScale split23_cal(2);
+  JetSubStructureUtils::KtSplittingScale split34_cal(3);
+
+  Split12(*jet) = split12_cal.result(*jet);
+  Split23(*jet) = split23_cal.result(*jet);
+  Split34(*jet) = split34_cal.result(*jet);
+
+  return;
 }

--- a/TheAccountant/OptimizationDump.h
+++ b/TheAccountant/OptimizationDump.h
@@ -36,12 +36,18 @@ private:
   xAOD::TStore *m_store; //!
   TTree* m_tree; //!
 
+  // everything below here is filled in the ttree
   float m_eventWeight; //!
   float m_effectiveMass; //!
   float m_totalTransverseMomentum; //!
   float m_totalTransverseMass; //!
   int m_numBJets; //!
   int m_numJets; //!
+
+  /* tagging */
+  int m_topTag_Loose; //!
+  int m_topTag_Medium; //!
+  int m_topTag_Tight; //!
 
 public:
   // this is a standard constructor

--- a/TheAccountant/VariableDefinitions.h
+++ b/TheAccountant/VariableDefinitions.h
@@ -2,6 +2,7 @@
 #define TheAccountant_VariableDefinitions_H
 
 // EDM includes
+#include "xAODEventInfo/EventInfo.h"
 #include "xAODJet/JetContainer.h"
 #include "xAODMuon/MuonContainer.h"
 #include "xAODEgamma/ElectronContainer.h"
@@ -9,6 +10,17 @@
 
 /* Caveats: input containers are assumed sorted */
 namespace VariableDefinitions {
+  // for tagging primarily, but an enum for working points
+  //  - an enum class enforces strong typing
+  enum class WP {
+    VeryLoose,
+    Loose,
+    Medium,
+    Tight
+  };
+  // helper to convert to actual string for the tagging
+  std::string wp2str(WP wp);
+
   // Effective Mass calculated using exclusive or inclusive definition depending on args
   //    Exclusive: Meff(met, jets, 4, 0, 0)
   //    Inclusive: Meff(met, jets, jets->size(), muons, els)
@@ -19,6 +31,29 @@ namespace VariableDefinitions {
 
   // Transverse Mass calculated using MET and leading lepton
   float mT(const xAOD::MissingET* met, const xAOD::MuonContainer* muons, const xAOD::ElectronContainer* els);
+
+  // top tagging on jets, set the eventInfo with "nTops_<WP>" int decoration
+  //    - static SG::AuxElement::Accessor< int > nTops_loose("nTops_<WP>");
+  //        * string of WP is equivalent to how you type it out in enum class
+  int topTag(const xAOD::EventInfo* eventInfo, const xAOD::JetContainer* jets, WP wp);
+  // top tagging on jet, set "isTop_<WP>" int decoration
+  bool topTag(const xAOD::Jet* jet, WP wp);
+
+  // returning subjettiness ratios for a given jet
+  //    - use Tau21 if set
+  //    - else use Tau2/Tau1 if both set
+  //    - else recompute using Nsubjettiness
+  float Tau21(const xAOD::Jet* jet);
+  float Tau32(const xAOD::Jet* jet);
+  void Nsubjettiness(const xAOD::Jet* jet, float alpha = 1.0);
+
+  // returning splitting scale calculations for a given jet
+  //    - use Split12 if set
+  //    - else recompute using KtSplittingScale
+  float Split12(const xAOD::Jet* jet);
+  float Split23(const xAOD::Jet* jet);
+  float Split34(const xAOD::Jet* jet);
+  void KtSplittingScale(const xAOD::Jet* jet);
 }
 
 #endif


### PR DESCRIPTION
- include top tagging
- subjettiness accessors
- kt splitting scale accessors
- working point definitions

We want to do our best in retrieving the substructure variables. If the decorations don't exist, we will compute them and add them. If we do not have access to constituents, that's a problem with the data we're looking at.

Also switch to using getAttribute() for jets and SG::AuxElement::Decorator for setting.
