### PR TITLE
Adding VeryLoose top tags to output.

### DIFF
--- a/Root/VariableDefinitions.cxx
+++ b/Root/VariableDefinitions.cxx
@@ -25,26 +25,26 @@ namespace VD = VariableDefinitions;
 
 std::string VD::wp2str(VD::WP wp){
   switch(wp){
-    case VD::WP::VeryLoose:
+  case VD::WP::VeryLoose:
       return "VeryLoose";
+      break;
+  case VD::WP::Loose:
+    return "Loose";
     break;
-    case VD::WP::Loose:
-      return "Loose";
-    break;
-    case VD::WP::Medium:
+  case VD::WP::Medium:
       return "Medium";
-    break;
-    case VD::WP::Tight:
-      return "Tight";
+      break;
+  case VD::WP::Tight:
+    return "Tight";
     break;
   case VD::WP::SmoothLoose:
-    return "SmoothTight";
+    return "SmoothLoose";
     break;
   case VD::WP::SmoothTight:
     return "SmoothTight";
     break;
   }
-
+  
   // should never reach here, we should be synced with the enum class
   return "BadWorkingPoint";
 }
@@ -267,10 +267,11 @@ bool VD::topTag(const xAOD::EventInfo* eventInfo, const xAOD::Jet* jet, VD::WP w
   bool isTop_tagged = false;
   switch(wp){
     case VD::WP::VeryLoose:
-    {
-      isTop_tagged = (jet->m()/1.e3 > 100.);
-    }
-    break;
+      {
+	isTop_tagged = (jet->m()/1.e3 > 100.);
+	//return isTop_tagged;
+      }
+      break;
     case VD::WP::Loose:
       {
 	static VD::accessor_t<int> tTag("LooseTopTag");
@@ -297,6 +298,7 @@ bool VD::topTag(const xAOD::EventInfo* eventInfo, const xAOD::Jet* jet, VD::WP w
   default:
     {
       isTop_tagged = false;
+      return isTop_tagged;
     }
     break;
   }

--- a/TheAccountant/OptimizationDump.h
+++ b/TheAccountant/OptimizationDump.h
@@ -45,12 +45,14 @@ private:
   int m_numJets; //!
   int m_numBJets; //!
   int m_numJetsLargeR; //!
+  int m_passTopTags; //!
   int m_numJetsVarR_top; //!
   int m_numJetsVarR_W; //!
 
   /* tagging */
   int m_n_topTag_SmoothLoose; //!
   int m_n_topTag_SmoothTight; //!
+  int m_n_topTag_VeryLoose; //!
   int m_n_topTag_Loose; //!
   int m_n_topTag_Tight; //!
 
@@ -80,6 +82,7 @@ private:
   std::array<float, 4> m_largeR_split12; //!
   std::array<float, 4> m_largeR_split23; //!
   std::array<int  , 4> m_largeR_nsj; //!
+  std::array<int  , 4> m_largeR_topTag_veryloose; //!
   std::array<int  , 4> m_largeR_topTag_loose; //!
   std::array<int  , 4> m_largeR_topTag_tight; //!
   std::array<int  , 4> m_largeR_topTag_smoothLoose; //!


### PR DESCRIPTION
Still not totally resolved, but starting this so @kratsg can take a look at what's up.

In particular, `m_largeR_topTag_veryloose` seems to always be 0 in the optimization ntuple, but the branch `m_passTopTags` provides a workaround at the moment ...
